### PR TITLE
John/merge master to juniper upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - tox
 
 env:
+  - TOXENV=py27-ginkgo
   - TOXENV=py27-hawthorn_community
   - TOXENV=py27-hawthorn_multisite
   - TOXENV=lint

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,15 @@ Reporting and data retrieval app for `Open edX <https://open.edx.org/>`__.
 
 .. _notice_section:
 
+26 Oct 2020 - Figures release 0.3.18
+====================================
+
+* FIX - Removed dependency on 'packaging.versions'
+
+  * https://github.com/appsembler/figures/pull/272
+  * NOTE: This PR updates a previous commit that required the `packaging` package
+
+
 16 Oct 2020 - Figures release 0.3.17
 ====================================
 

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,26 @@ Reporting and data retrieval app for `Open edX <https://open.edx.org/>`__.
 
 .. _notice_section:
 
+16 Oct 2020 - Figures release 0.3.17
+====================================
+
+* Reworked SiteMonthlyMetrics registered users metric. This was causing the `/figures/api/site-monthly-metrics/registered_users` endpoint to timeout with a 500 error
+
+  * https://github.com/appsembler/figures/pull/268
+
+* Fixed Ginkgo (Django Filter 0.11.0) Backward compatibility issues
+
+  * https://github.com/appsembler/figures/pull/266
+  * https://github.com/appsembler/figures/pull/269
+
+* UI Bug fix: Add success feedback to csv export dialog
+
+  * https://github.com/appsembler/figures/pull/265
+
+* Bump http-proxy from 1.18.0 to 1.18.1 in /frontend
+
+  * https://github.com/appsembler/figures/pull/254
+
 
 28 Sep 2020 - Figures release 0.3.16
 ====================================

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -314,8 +314,14 @@ class ProgressOverview extends Component {
         </HeaderAreaLayout>
         {this.state.csvExportProgress ? (
           <div className={cx({ 'container': true, 'csv-export-content': true})}>
-            <h2>Exporting your CSV data...</h2>
-            <p>Please don't close this browser tab.</p>
+            {(this.state.csvExportProgress < 1) ? [
+              <h2>Exporting your CSV data...</h2>,
+              <p>Please don't close this browser tab.</p>
+            ] : [
+              <h2>Export successful!</h2>,
+              <p>Depending on your browser settings, you will either be prompted with a prompt to save the generated file, or the file will be automatically downloaded into your default Downloads folder.</p>,
+              <p>It is now safe to close the exporter.</p>,
+            ]}
             <div className={styles['progress-bar']}>
               <span className={styles['progress-bar-inner']} style={{ width: this.state.csvExportProgress * 100 + '%'}}></span>
             </div>

--- a/frontend/src/views/_progress-overview-content.scss
+++ b/frontend/src/views/_progress-overview-content.scss
@@ -229,6 +229,13 @@ button.export-the-csv-button {
     margin: 0 0 calcRem(20);
   }
 
+  p {
+    font-size: calcRem(14);
+    max-width: calcRem(800);
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   .progress-bar {
     width: 100%;
     max-width: calcRem(500);
@@ -264,6 +271,7 @@ button.close-csv-button {
   outline: none;
   border-radius: 50px;
   transition: all 0.3s ease-in-out;
+  font-size: calcRem(16);
 
   &:hover {
     cursor: pointer;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2691,7 +2691,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
+debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3425,9 +3425,9 @@ event-emitter@~0.3.5:
     es5-ext "~0.10.14"
 
 eventemitter3@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
-  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@^3.0.0:
   version "3.0.0"
@@ -3826,11 +3826,9 @@ flat-cache@^1.2.1:
     write "^0.2.1"
 
 follow-redirects@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
-  integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
-  dependencies:
-    debug "^3.0.0"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -4431,9 +4429,9 @@ http-proxy-middleware@~0.17.4:
     micromatch "^2.3.11"
 
 http-proxy@^1.16.2:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
-  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   dependencies:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.3.16',
+    version='0.3.17',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='Figures',
-    version='0.3.17',
+    version='0.3.18',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -55,7 +55,6 @@ from figures.metrics import (
     get_total_course_completions_for_time_period,
     get_total_enrollments_for_time_period,
     get_total_site_courses_for_time_period,
-    get_total_site_users_for_time_period,
     get_total_site_users_joined_for_time_period,
 
 )
@@ -308,25 +307,7 @@ class TestSiteMetricsGettersStandalone(object):
         count = get_active_users_for_time_period(site=self.site,
                                                  start_date=start_date,
                                                  end_date=end_date)
-        assert count == len(sm_in) -1
-
-    def test_get_total_site_users_for_time_period(self):
-        '''
-        TODO: add users who joined before and after the time period, and
-        compare the count to the users created on or before the end date
-
-        TODO: Create
-        '''
-        users = create_users_joined_over_time(
-            site=self.site,
-            is_multisite=figures.helpers.is_multisite(),
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
-        count = get_total_site_users_for_time_period(
-            site=self.site,
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
-        assert count == len(users)
+        assert count == len(sm_in) - 1
 
     def test_get_total_site_users_joined_for_time_period(self):
         '''
@@ -365,7 +346,6 @@ class TestSiteMetricsGettersStandalone(object):
                                                        end_date=self.data_end_date)
 
         assert count == self.site_daily_metrics[-1].course_count
-
 
     def test_get_monthly_site_metrics(self):
         '''
@@ -442,23 +422,6 @@ class TestSiteMetricsGettersMultisite(object):
 
         assert count == len(student_module_sets)
 
-    def test_get_total_site_users_for_time_period(self):
-        '''
-        TODO: add users who joined before and after the time period, and
-        compare the count to the users created on or before the end date
-
-        TODO: Create
-        '''
-        users = create_users_joined_over_time(
-            site=self.alpha_site,
-            is_multisite=figures.helpers.is_multisite(),
-            start_date=self.data_start_date,
-            end_date=self.data_end_date)
-        count = get_total_site_users_for_time_period(site=self.alpha_site,
-                                                     start_date=self.data_start_date,
-                                                     end_date=self.data_end_date)
-        assert count == len(users)
-
     def test_get_total_site_users_joined_for_time_period(self):
         '''
         TODO: add users who joined before and after the time period, and
@@ -493,7 +456,6 @@ class TestSiteMetricsGettersMultisite(object):
                                                        start_date=self.data_start_date,
                                                        end_date=self.data_end_date)
         assert count == self.alpha_site_daily_metrics[-1].course_count
-
 
     def test_get_monthly_site_metrics(self):
         '''

--- a/tests/metrics/test_registered_users.py
+++ b/tests/metrics/test_registered_users.py
@@ -1,0 +1,101 @@
+"""Tests for registered user metrics
+
+This module tests metrics functionality in `figures.metrics` that work with
+the "registered user" metric
+
+The registered user metric provides the count of how many users have registered
+for a given site for a time range
+
+TODO: Provide details here
+* Figures UI registered users on a site
+* The pipeline, storage, API retrieval, and any derivative metrics
+
+# Developer Note
+
+* Initially, we have basic tests for coverage
+
+* We've just changed the metric from live User model `date_joined` queries to
+  using stored data in `SiteDailyMetrics.total_user_count`
+* We need to deploy quickly, so doing minimal testing to start
+
+
+"""
+
+from datetime import datetime
+import pytest
+
+from figures.metrics import get_total_site_users_for_time_period
+
+from tests.factories import (
+    SiteDailyMetricsFactory,
+    SiteFactory,
+)
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def sdm_test_data(db):
+    """Quick-n-dirty test data construction
+
+    Expected count is the highest 'total_user_count'
+    """
+    dates = [
+        datetime(year=2020, month=3, day=15),
+        datetime(year=2020, month=4, day=1),
+        datetime(year=2020, month=4, day=15),
+        datetime(year=2020, month=4, day=30),
+        datetime(year=2020, month=5, day=1)
+    ]
+
+    our_date_range = [
+        datetime(year=2020, month=4, day=1),
+        datetime(year=2020, month=4, day=30),
+    ]
+    my_site = SiteFactory()
+    other_site = SiteFactory()
+
+    my_sdm = [
+        # month before
+        SiteDailyMetricsFactory(site=my_site,
+                                date_for=dates[0],
+                                total_user_count=10),
+        # in our date range
+        SiteDailyMetricsFactory(site=my_site,
+                                date_for=dates[1],
+                                total_user_count=20),
+        SiteDailyMetricsFactory(site=my_site,
+                                date_for=dates[2],
+                                total_user_count=30),
+        SiteDailyMetricsFactory(site=my_site,
+                                date_for=dates[3],
+                                total_user_count=25),
+        # month after
+        SiteDailyMetricsFactory(site=my_site,
+                                date_for=dates[4],
+                                total_user_count=500),
+    ]
+    # Create one SDM record for the other site in the month we query
+    other_sdm = [
+        SiteDailyMetricsFactory(site=other_site,
+                                date_for=dates[2],
+                                total_user_count=13)]
+    return dict(
+        our_date_range=our_date_range,
+        my_site=my_site,
+        other_site=other_site,
+        my_sdm=my_sdm,
+        other_sdm=other_sdm,
+        expected_count=30,
+    )
+
+
+def test_get_total_site_users_for_month(sdm_test_data):
+    """
+    """
+    my_site = sdm_test_data['my_site']
+    start_date, end_date = sdm_test_data['our_date_range']
+    count = get_total_site_users_for_time_period(
+        site=my_site,
+        start_date=start_date,
+        end_date=end_date)
+    assert count == sdm_test_data['expected_count']

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-'''Tests Figures filter classes
+"""Tests Figures filter classes
 
 Currently uses Django TestCase style classes instead of pytest style classes
 so that we can use TestCase.assertQuerysetEqual
@@ -9,11 +9,22 @@ Test Debt
 Field parameters 'lookup_type' and 'lookup_expr'
 
 We are not adequately testing 'lookup_exr', which is supported only in
-Django Filters 1.0.0 and greater. Prior to Django Filters 1.0.0, 'lookup_type'
+Django Filter 1.0.0 and greater. Prior to Django Filters 1.0.0, 'lookup_type'
 was used.
 
-Open edX Ginkgo uses Django Filteres 0.11.0.
-'''
+* Open edX Ginkgo uses Django Filter 0.11.0
+* Open edX Hawthorn uses Django Filter 1.0.4
+* Open edX Juniper uses Django Fitler 2.2.0
+
+TODO: Create mock view that tests the filters
+
+Doing this instead of directly calling the filter make sure that the execution
+chain is called. One of the defects we find is that our tests currently don't
+adequately tests for method signature differences for our custom filter methods.
+We need to make sure that our custom methods are properly handled by the
+different versions of "Django Filter", as different major relases are used by
+different Open edX releases.
+"""
 
 from dateutil.parser import parse as dateutil_parse
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,16 @@
 Currently uses Django TestCase style classes instead of pytest style classes
 so that we can use TestCase.assertQuerysetEqual
 
+
+Test Debt
+=========
+Field parameters 'lookup_type' and 'lookup_expr'
+
+We are not adequately testing 'lookup_exr', which is supported only in
+Django Filters 1.0.0 and greater. Prior to Django Filters 1.0.0, 'lookup_type'
+was used.
+
+Open edX Ginkgo uses Django Filteres 0.11.0.
 '''
 
 from dateutil.parser import parse as dateutil_parse


### PR DESCRIPTION
This gets the juniper upgrade current with Figures 0.3.18 and addresses an issue with using `packaging.version`. Because not all Open edX deployments will have `packaging` installed, we're doing a quick hack to just check the major version of django_filters.__version__ to provide compatibility between Ginkgo, Hawthorn, and Juniper.

This PR should also get all the tox environments running (we hope). We test against Python 2.7, 3.5, and 3.8