### PR TITLE
Update Tox to Fix Juniper 'mock 3.0.5' version support, clean up travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ node_js:
 # command to install dependencies
 install:
   - pip install flake8 tox
+  # Remarking out codecov and leaving here as a reference until we decide what
+  # we are going to do moving forward with running coverage tests in the GitHub
+  # repo
   # - pip install -r devsite/requirements/hawthorn_community.txt
   # - pip install pytest-cov flake8 tox
   - cd frontend && yarn && cd ..
@@ -32,18 +35,12 @@ install:
 script:
   - cd frontend && yarn && cd ..
   - flake8 figures
+  # Remarking out codecov and leaving here as a reference until we decide what
+  # we are going to do moving forward with running coverage tests in the GitHub
+  # repo
   # - py.test --cov=./
   # - bash <(curl -s https://codecov.io/bash)
   - tox
-
-# env:
-#   - TOXENV=py27-ginkgo
-#   - TOXENV=py27-hawthorn_community
-#   - TOXENV=py27-hawthorn_multisite
-#   - TOXENV=py35-juniper_community
-#   - TOXENV=py38-juniper_community
-#   - TOXENV=lint
-#   - TOXENV=edx_lint_check
 
 deploy:
   provider: pypi

--- a/devsite/requirements/py35_juniper_community.txt
+++ b/devsite/requirements/py35_juniper_community.txt
@@ -1,0 +1,79 @@
+# Requirements needed by the devsite app server and test suite
+# For initial development, we're just importing all the packages needed
+# for both running the devsite server and for the pytest dependencies
+#
+
+# Versions should match those used in Open edX Juniper
+
+##
+## General Python package dependencies
+###
+
+celery==3.1.26.post2
+django-celery==3.3.1
+six==1.14.0
+
+# Faker is used to seed mock data in devsite
+Faker==4.1.0 
+python-dateutil==2.7.3
+path.py==12.4.0
+
+pytz==2020.1
+
+##
+## Django package dependencies
+##
+
+Django==2.2.15
+
+djangorestframework==3.9.4
+django-countries==5.5
+django-webpack-loader==0.7.0
+django-model-utils==4.0.0
+django-filter==2.3.0
+django-environ==0.4.5
+
+jsonfield==2.1.1
+
+##
+## Documentation (Sphinx) dependencies
+##
+
+Sphinx==3.1.2
+#recommonmark==0.6.0 #! 0.4.0 #caniusepython3 flagged
+
+##
+## Open edX package dependencies
+##
+
+edx-opaque-keys[django]==2.1.0
+#edx-drf-extensions==6.0.0
+
+edx-organizations==5.2.0
+
+##
+## Devsite 
+##
+
+django-debug-toolbar==2.2
+
+
+##
+## Test dependencies
+##
+
+coverage==5.1
+factory-boy==2.8.1
+flake8==3.8.1
+pylint==2.4.2
+pylint-django==2.0.11
+pytest==5.3.5
+pytest-django==3.8.0
+pytest-mock==3.2.0
+pytest-pythonpath==0.7.3 
+pytest-cov==2.8.1
+tox==3.15.0
+freezegun==0.3.12
+edx-lint==1.4.1
+
+mock==3.0.5

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,8 @@ envlist =
 	py27-ginkgo
 	py27-hawthorn_community
 	py27-hawthorn_multisite
-	py{35,38}-juniper_community
+	py35-juniper_community
+	py38-juniper_community
 	lint
 	edx_lint_check
 
@@ -26,7 +27,8 @@ deps =
 	ginkgo: -r{toxinidir}/devsite/requirements/ginkgo.txt
 	hawthorn_community: -r{toxinidir}/devsite/requirements/hawthorn_community.txt
 	hawthorn_multisite: -r{toxinidir}/devsite/requirements/hawthorn_multisite.txt
-	juniper_community: -r{toxinidir}/devsite/requirements/juniper_community.txt
+	py35_juniper_community: -r{toxinidir}/devsite/requirements/py35_juniper_community.txt
+	py38_juniper_community: -r{toxinidir}/devsite/requirements/juniper_community.txt
 
 whitelist_externals =
 	git
@@ -37,13 +39,15 @@ setenv =
 	PYTHONPATH = {toxinidir}
 	# We don't need to call out Hawthorn as it is the current default environment
 	ginkgo: OPENEDX_RELEASE = GINKGO
-	juniper_community: OPENEDX_RELEASE = JUNIPER
+	py35_juniper_community: OPENEDX_RELEASE = JUNIPER
+	py38_juniper_community: OPENEDX_RELEASE = JUNIPER
 
 commands = 
 	ginkgo: pytest -c pytest-ginkgo.ini {posargs}
 	hawhthorn_community: pytest {posargs}
 	hawhthorn_multisite: pytest {posargs}
-	juniper_community: pytest -c pytest-juniper.ini {posargs}
+	py35_juniper_community: pytest -c pytest-juniper.ini {posargs}
+	py38_juniper_community: pytest -c pytest-juniper.ini {posargs}
 
 [testenv:lint]
 basepython=python2


### PR DESCRIPTION
Tested tox locally. Py35 was skipped, but the others checked out. I tested pip install py35_juniper_community.txt file with Python 3.8 to make sure Mock 3.0.5 and pytest-mock 3.2.0 would install together