### PR TITLE
Maple upgrade - Tox update + test pruning

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 # you wish to override
 
 # Set the edx-platform named release. The default release is "hawthorn"
-OPENEDX_RELEASE=juniper
+OPENEDX_RELEASE=maple
 
 # Env settings TODO
 # - PyPI authentication for Twine

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,6 @@ name: figures tests
 on:
     push:
         branches:
-            - main
             - develop/maple
     pull_request:
 
@@ -13,16 +12,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: 2.7
-            tox-env: py27-ginkgo
-          - python: 2.7
-            tox-env: py27-hawthorn
-          - python: 2.7
-            tox-env: py27-hawthorn_multisite
-          - python: 3.5
-            tox-env: py35-juniper_community
-          - python: 3.5
-            tox-env: py35-juniper_multisite
+          - python: 3.8
+            tox-env: py38-maple_community
+          - python: 3.8
+            tox-env: py35-maple_multisite
           - python: 3.8
             tox-env: lint
           - python: 3.8

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -23,7 +23,7 @@ PROJECT_ROOT_DIR = os.path.dirname(DEVSITE_BASE_DIR)
 env = environ.Env(
     DEBUG=(bool, True),
     ALLOWED_HOSTS=(list, []),
-    OPENEDX_RELEASE=(str, 'JUNIPER'),
+    OPENEDX_RELEASE=(str, 'MAPLE'),
     FIGURES_IS_MULTISITE=(bool, False),
     ENABLE_DEVSITE_CELERY=(bool, True),
     ENABLE_OPENAPI_DOCS=(bool, False),
@@ -89,7 +89,7 @@ INSTALLED_APPS = [
 if ENABLE_DEVSITE_CELERY:
     INSTALLED_APPS.append('djcelery')
 
-<<<<<<< HEAD
+
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -28,7 +28,7 @@ def root(*args):
 
 
 env = environ.Env(
-    OPENEDX_RELEASE=(str, 'JUNIPER'),
+    OPENEDX_RELEASE=(str, 'MAPLE'),
 )
 
 environ.Env.read_env(join(dirname(dirname(__file__)), '.env'))

--- a/figures/compat.py
+++ b/figures/compat.py
@@ -27,6 +27,20 @@ from __future__ import absolute_import
 from django.http import Http404
 from figures.helpers import as_course_key
 
+from openedx.core.release import RELEASE_LINE
+
+from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory  # noqa pylint: disable=unused-import,import-error
+from lms.djangoapps.certificates.models import GeneratedCertificate  # noqa pylint: disable=unused-import,import-error
+from lms.djangoapps.courseware.models import StudentModule  # noqa pylint: disable=unused-import,import-error
+from lms.djangoapps.courseware.courses import get_course_by_id  # noqa pylint: disable=unused-import,import-error
+from opaque_keys.edx.django.models import CourseKeyField  # noqa pylint: disable=unused-import,import-error
+
+# preemptive addition. Added it here to avoid adding to figures.models
+# In fact, we should probably do a refactoring that makes all Figures import it
+# from here
+from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment  # noqa pylint: disable=unused-import,import-error
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=unused-import,import-error
+
 
 class UnsuportedOpenedXRelease(Exception):
     pass
@@ -38,21 +52,10 @@ class CourseNotFound(Exception):
     pass
 
 
-
-from openedx.core.release import RELEASE_LINE
-
-from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory  # noqa pylint: disable=unused-import,import-error
-from lms.djangoapps.certificates.models import GeneratedCertificate  # noqa pylint: disable=unused-import,import-error
-from lms.djangoapps.courseware.models import StudentModule  # noqa pylint: disable=unused-import,import-error
-from lms.djangoapps.courseware.courses import get_course_by_id  # noqa pylint: disable=unused-import,import-error
-from opaque_keys.edx.django.models import CourseKeyField  # noqa pylint: disable=unused-import,import-error
-
-
-# preemptive addition. Added it here to avoid adding to figures.models
-# In fact, we should probably do a refactoring that makes all Figures import it
-# from here
-from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment  # noqa pylint: disable=unused-import,import-error
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=unused-import,import-error
+if RELEASE_LINE != 'maple':
+    raise UnsuportedOpenedXRelease(
+      'The current Open edX is {}. This release of Figures requires Maple'.format(
+        RELEASE_LINE))
 
 
 def course_grade(learner, course):
@@ -61,7 +64,6 @@ def course_grade(learner, course):
 
     Returns the course grade for the specified learner and course
     """
-    
     return CourseGradeFactory().read(learner, course)
 
 
@@ -91,9 +93,10 @@ def course_grade_from_course_id(learner, course_id):
 
 def chapter_grade_values(chapter_grades):
     '''
+    **Maple upgrade note: We should be able to either do away with this function
+    or assume chapter_grades is a dict. **
 
     Ginkgo introduced ``BlockUsageLocator``into the ``chapter_grades`` collection
-
 
     For the current functionality we need, we can simply check if chapter_grades
     acts as a list or a dict

--- a/mocks/openedx/core/release.py
+++ b/mocks/openedx/core/release.py
@@ -2,4 +2,4 @@
 Identify the release of Open edX platform
 """
 
-RELEASE_LINE = 'juniper'
+RELEASE_LINE = 'maple'

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -45,11 +45,8 @@ from figures.models import (
     SiteMauMetrics,
 )
 
-from tests.helpers import (
-    organizations_support_sites,
-    OPENEDX_RELEASE,
-    GINKGO,
-)
+from tests.helpers import organizations_support_sites
+
 import six
 
 
@@ -165,9 +162,7 @@ class CourseOverviewFactory(DjangoModelFactory):
         COURSE_ID_STR_TEMPLATE.format(n)))
     display_name = factory.Sequence(lambda n: 'SFA Course {}'.format(n))
     org = 'StarFleetAcademy'
-
-    if not OPENEDX_RELEASE == GINKGO:
-        version = CourseOverview.VERSION
+    version = CourseOverview.VERSION
     display_org_with_default = factory.LazyAttribute(lambda o: o.org)
     created = factory.fuzzy.FuzzyDateTime(datetime.datetime(
         2018, 2, 1, tzinfo=utc))
@@ -235,57 +230,42 @@ class StudentModuleFactory(DjangoModelFactory):
         return cls(**kwargs)
 
 
-if OPENEDX_RELEASE == GINKGO:
-    class CourseEnrollmentFactory(DjangoModelFactory):
-        class Meta:
-            model = CourseEnrollment
+class CourseEnrollmentFactory(DjangoModelFactory):
+    class Meta(object):
+        model = CourseEnrollment
 
-        user = factory.SubFactory(
-            UserFactory,
-        )
-        course_id = factory.SelfAttribute('course_overview.id')
-        course_overview = factory.SubFactory(CourseOverviewFactory)
-        created = factory.Sequence(lambda n:
-            (datetime.datetime(2018, 1, 1) + datetime.timedelta(days=n)).replace(tzinfo=utc))
+    user = factory.SubFactory(UserFactory)
 
-else:
-
-    class CourseEnrollmentFactory(DjangoModelFactory):
-        class Meta(object):
-            model = CourseEnrollment
-
-        user = factory.SubFactory(UserFactory)
-
-        created = factory.Sequence(lambda n:
-            (datetime.datetime(2018, 1, 1) + datetime.timedelta(days=n)).replace(tzinfo=utc))
+    created = factory.Sequence(lambda n:
+        (datetime.datetime(2018, 1, 1) + datetime.timedelta(days=n)).replace(tzinfo=utc))
 
 
-        @classmethod
-        def _create(cls, model_class, *args, **kwargs):
-            manager = cls._get_manager(model_class)
-            course_kwargs = {}
-            for key in kwargs.keys():
-                if key.startswith('course__'):
-                    course_kwargs[key.split('__')[1]] = kwargs.pop(key)
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        manager = cls._get_manager(model_class)
+        course_kwargs = {}
+        for key in kwargs.keys():
+            if key.startswith('course__'):
+                course_kwargs[key.split('__')[1]] = kwargs.pop(key)
 
-            if 'course' not in kwargs:
-                course_id = kwargs.get('course_id')
-                course_overview = None
-                if course_id is not None:
-                    if isinstance(course_id, six.string_types):
-                        course_id = as_course_key(course_id)
-                        course_kwargs.setdefault('id', course_id)
+        if 'course' not in kwargs:
+            course_id = kwargs.get('course_id')
+            course_overview = None
+            if course_id is not None:
+                if isinstance(course_id, six.string_types):
+                    course_id = as_course_key(course_id)
+                    course_kwargs.setdefault('id', course_id)
 
-                    try:
-                        course_overview = CourseOverview.get_from_id(course_id)
-                    except CourseOverview.DoesNotExist:
-                        pass
+                try:
+                    course_overview = CourseOverview.get_from_id(course_id)
+                except CourseOverview.DoesNotExist:
+                    pass
 
-                if course_overview is None:
-                    course_overview = CourseOverviewFactory(**course_kwargs)
-                kwargs['course'] = course_overview
+            if course_overview is None:
+                course_overview = CourseOverviewFactory(**course_kwargs)
+            kwargs['course'] = course_overview
 
-            return manager.create(*args, **kwargs)
+        return manager.create(*args, **kwargs)
 
 
 class CourseAccessRoleFactory(DjangoModelFactory):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,13 +13,16 @@ from opaque_keys.edx.keys import CourseKey
 from organizations.models import Organization
 
 
-# Ginkgo is the earliest supported platform
-GINKGO = 'GINKGO'
-HAWTHORN = 'HAWTHORN'
-
-
 def platform_release():
-    return os.environ.get('OPENEDX_RELEASE', HAWTHORN)
+    """Identifies for which Open edX release we should test
+    This is to handle breaking changes between releases
+
+    With the Maple upgrade, we've removed all Ginkgo handling, which in turn
+    removed all references to this function and OPENEDX_RELEASE
+    However, we will retain it "for now", at least until we upgrade post-Maple,
+    and decide if we retain this testing feature or remove it
+    """
+    return os.environ.get('OPENEDX_RELEASE', 'MAPLE')
 
 
 OPENEDX_RELEASE = platform_release()

--- a/tests/metrics/test_learner_course_grades.py
+++ b/tests/metrics/test_learner_course_grades.py
@@ -17,20 +17,13 @@ from tests.factories import (
     GeneratedCertificateFactory,
     )
 
-from tests.helpers import OPENEDX_RELEASE, GINKGO
 
 # Mock objects to test course and course section grade metrics
-if OPENEDX_RELEASE == GINKGO:
-    from lms.djangoapps.grades.new.course_grade import (
-        MockAggregatedScore,
-        MockSubsectionGrade,
-        )
 
-else:
-    from lms.djangoapps.grades.course_grade import (
-        MockAggregatedScore,
-        MockSubsectionGrade,
-        )
+from lms.djangoapps.grades.course_grade import (
+    MockAggregatedScore,
+    MockSubsectionGrade,
+    )
 
 
 @pytest.mark.django_db
@@ -39,10 +32,7 @@ class TestLearnerCourseGrades(object):
     @pytest.fixture(autouse=True)
     def setup(self, db):
         self.course_enrollment = CourseEnrollmentFactory()
-        if OPENEDX_RELEASE == GINKGO:
-            self.course_id = self.course_enrollment.course_id
-        else:
-            self.course_id = self.course_enrollment.course.id
+        self.course_id = self.course_enrollment.course.id
 
         self.lcg = LearnerCourseGrades(self.course_enrollment.user.id,
                                        self.course_id)

--- a/tests/models/test_enrollment_data_model.py
+++ b/tests/models/test_enrollment_data_model.py
@@ -33,11 +33,7 @@ from tests.factories import (
     OrganizationCourseFactory,
     SiteFactory,
     UserFactory)
-from tests.helpers import (
-    OPENEDX_RELEASE,
-    GINKGO,
-    organizations_support_sites
-)
+from tests.helpers import organizations_support_sites
 
 if organizations_support_sites():
     from tests.factories import UserOrganizationMappingFactory
@@ -111,7 +107,6 @@ def site_data(db, settings):
     return site_data
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO, reason='Breaks on CourseEnrollmentFactory')
 def test_set_enrollment_data_new_record(site_data):
     """Test we create a new EnrollmentData record
 
@@ -134,7 +129,6 @@ def test_set_enrollment_data_new_record(site_data):
     assert obj.user == lcgm.user
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO, reason='Breaks on CourseEnrollmentFactory')
 def test_set_enrollment_data_update_existing(site_data):
     """Test we update an existing EnrollmentData record
     """

--- a/tests/models/test_enrollment_data_update_metrics.py
+++ b/tests/models/test_enrollment_data_update_metrics.py
@@ -53,7 +53,6 @@ if organizations_support_sites():
                                         organization=org) for user in users]
 
 
-# @pytest.mark.skipif(OPENEDX_RELEASE == GINKGO, reason='Breaks on CourseEnrollmentFactory')
 @pytest.mark.django_db
 class TestUpdateMetrics(object):
     """Test EnrollmentDataManager.update_metrics method

--- a/tests/pipeline/test_course_daily_metrics.py
+++ b/tests/pipeline/test_course_daily_metrics.py
@@ -28,12 +28,8 @@ from tests.factories import (
     SiteFactory,
     StudentModuleFactory,
 )
+from tests.helpers import organizations_support_sites
 
-from tests.helpers import (
-    organizations_support_sites,
-    OPENEDX_RELEASE,
-    GINKGO,
-)
 from six.moves import range
 
 
@@ -86,12 +82,8 @@ class TestCourseDailyMetricsPipelineFunctions(object):
     def setup(self, db):
         self.today = datetime.date(2018, 6, 1)
         self.course_overview = CourseOverviewFactory()
-        if OPENEDX_RELEASE == GINKGO:
-            self.course_enrollments = [CourseEnrollmentFactory(
-                course_id=self.course_overview.id) for i in range(4)]
-        else:
-            self.course_enrollments = [CourseEnrollmentFactory(
-                course=self.course_overview) for i in range(4)]
+        self.course_enrollments = [CourseEnrollmentFactory(
+            course=self.course_overview) for i in range(4)]
 
         if organizations_support_sites():
             self.my_site = SiteFactory(domain='my-site.test')
@@ -276,10 +268,7 @@ class TestCourseDailyMetricsLoader(object):
 
     def test_load(self, monkeypatch):
         # pick a course, any course (we'll just pick the first, but doesn't matter which)
-        if OPENEDX_RELEASE == GINKGO:
-            course_id = self.course_enrollments[0].course_id
-        else:
-            course_id = self.course_enrollments[0].course.id
+        course_id = self.course_enrollments[0].course.id
 
         def get_data(self, date_for, ed_next=False):
             return {

--- a/tests/tasks/test_daily_tasks.py
+++ b/tests/tasks/test_daily_tasks.py
@@ -77,7 +77,7 @@ from tests.factories import (CourseDailyMetricsFactory,
                              CourseOverviewFactory,
                              SiteDailyMetricsFactory,
                              SiteFactory)
-from tests.helpers import OPENEDX_RELEASE, GINKGO, FakeException, fake_course_key
+from tests.helpers import FakeException, fake_course_key
 
 
 @pytest.mark.parametrize('extra_params', [{}, {'ed_next': True}])
@@ -189,8 +189,6 @@ def test_populate_daily_metrics_for_site_basic(transactional_db,
     assert set(collected_course_ids) == set(course_ids)
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO,
-                    reason='Apparent Django 1.8 incompatibility')
 @pytest.mark.parametrize('extra_params', [{}, {'ed_next': True}])
 def test_populate_daily_metrics_for_site_error_on_cdm(transactional_db,
                                                       monkeypatch,
@@ -230,8 +228,6 @@ def test_populate_daily_metrics_for_site_error_on_cdm(transactional_db,
     assert last_log.message == expected_msg
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO,
-                    reason='Apparent Django 1.8 incompatibility')
 @pytest.mark.parametrize('extra_params', [{}, {'ed_next': True}])
 def test_populate_daily_metrics_for_site_site_dne(transactional_db,
                                                   monkeypatch,
@@ -256,8 +252,6 @@ def test_populate_daily_metrics_for_site_site_dne(transactional_db,
     assert last_log.message == expected_message.format(bad_site_id)
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO,
-                    reason='Apparent Django 1.8 incompatibility')
 @pytest.mark.parametrize('func', [
     populate_daily_metrics, populate_daily_metrics_next
 ])
@@ -303,8 +297,6 @@ def test_populate_daily_metrics_site_level_error(transactional_db,
 # TODO: def test_populate_daily_metrics_future_date_error
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO,
-                    reason='Apparent Django 1.8 incompatibility')
 def test_populate_daily_metrics_enrollment_data_error(transactional_db,
                                                       monkeypatch,
                                                       caplog):
@@ -336,8 +328,6 @@ def test_populate_daily_metrics_enrollment_data_error(transactional_db,
     assert last_log.message == expected_msg
 
 
-@pytest.mark.skipif(OPENEDX_RELEASE == GINKGO,
-                    reason='Broken test. Apparent Django 1.8 incompatibility')
 @pytest.mark.parametrize('func', [
     populate_daily_metrics, populate_daily_metrics_next
 ])

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -62,8 +62,8 @@ def patch_module(module_path, extra_properties=None):
 
 # TODO: Test with no release line
 
-@patch('openedx.core.release.RELEASE_LINE', 'juniper')
-def test_release_line_with_juniper():
+@patch('openedx.core.release.RELEASE_LINE', 'maple')
+def test_release_line_with_maple():
     """Test Hawthorn compat path works
 
     Yes, we have a number of assertions here. We are testing the state of
@@ -83,7 +83,7 @@ def test_release_line_with_juniper():
                                       {'CourseKeyField': 'ckf'}):
                         import figures.compat
                         reload(figures.compat)
-                        assert figures.compat.RELEASE_LINE == 'juniper'
+                        assert figures.compat.RELEASE_LINE == 'maple'
                         assert hasattr(figures.compat, 'CourseGradeFactory')
                         assert figures.compat.CourseGradeFactory == 'cgf'
                         assert hasattr(figures.compat, 'GeneratedCertificate')

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,10 @@
 
 [tox]
 envlist =
-	py27-ginkgo
-	py27-hawthorn
-	py27-hawthorn_multisite
-	py35-juniper_community
-	py35-juniper_multisite
+	py38-maple_community
+	# py38-maple_multisite
 	lint
-	edx_lint_check
+	# edx_lint_check
 
 skip_missing_interpreters=true
 
@@ -24,11 +21,8 @@ skip_missing_interpreters=true
 
 [testenv]
 deps =
-	ginkgo: -r{toxinidir}/devsite/requirements/ginkgo.txt
-	hawthorn: -r{toxinidir}/devsite/requirements/hawthorn.txt
-	hawthorn_multisite: -r{toxinidir}/devsite/requirements/hawthorn_multisite.txt
-	juniper_community: -r{toxinidir}/devsite/requirements/juniper_community.txt
-	juniper_multisite: -r{toxinidir}/devsite/requirements/juniper_multisite.txt
+	maple_community: -r{toxinidir}/devsite/requirements/community.txt
+	maple_multisite: -r{toxinidir}/devsite/requirements/multisite.txt
 	-r{toxinidir}/devsite/requirements/test.txt
 
 whitelist_externals =
@@ -36,42 +30,36 @@ whitelist_externals =
 	edx_lint_check
 
 setenv =
-	DJANGO_SETTINGS_MODULE = devsite.test_settings
 	PYTHONPATH = {toxinidir}
-	ginkgo: OPENEDX_RELEASE = GINKGO
-	hawthorn: OPENEDX_RELEASE = HAWTHORN
-	hawthorn_multisite: OPENEDX_RELEASE = HAWTHORN
-	juniper_community: OPENEDX_RELEASE = JUNIPER
-	juniper_multisite: OPENEDX_RELEASE = JUNIPER
+	maple_community: OPENEDX_RELEASE = MAPLE
+	maple_multisite: OPENEDX_RELEASE = MAPLE
 
 commands = 
-	ginkgo: pytest -c pytest-ginkgo.ini {posargs}
-	hawthorn: pytest -c pytest-hawthorn.ini {posargs}
-	hawthorn_multisite: pytest -c pytest-hawthorn.ini {posargs}
-	juniper_community: pytest -c pytest-juniper.ini {posargs}
-	juniper_multisite: pytest -c pytest-juniper.ini {posargs}
+	maple_community: pytest {posargs}
+	maple_multisite: pytest {posargs}
+
 
 [testenv:lint]
-basepython=python2
+basepython=python3
 deps =
-	-r{toxinidir}/devsite/requirements/hawthorn.txt
+	-r{toxinidir}/devsite/requirements/community.txt
 commands =
 	flake8 figures devsite
 	pylint --load-plugins pylint_django ./figures
 
 [testenv:edx_lint_check]
-basepython=python2
+basepython=python3
 deps =
-	-r{toxinidir}/devsite/requirements/hawthorn.txt
+	-r{toxinidir}/devsite/requirements/community.txt
 commands =
 	edx_lint write pylintrc
 	echo "If this fails, then you need to run '$ tox -e write_edx_lint' locally"
 	git diff --exit-code  # Ensure pylintrc is up to date
 
 [testenv:write_edx_lint]
-basepython=python2
+basepython=python3
 deps =
-	-r{toxinidir}/devsite/requirements/hawthorn.txt
+	-r{toxinidir}/devsite/requirements/community.txt
 commands =
 	edx_lint write pylintrc
 


### PR DESCRIPTION
Updated Tox to run for Maple only, removing prior Open edX release references, as the Figures Maple support release series makes a clean break from prior Open edX releases

* The community tests now run
* Also, pytest can run on its own without Tox
* The pylint target also now runs and show lint errors
* remarked out multisite mode in tox.ini because edx-organizations still requires update, but left it enabled for now in the github workflowx tests.yml
* Remarked out edx_lint_check in Tox, but still enabled in the github workflows/tests.yml. It fails locally (at least it has always failed locally for me)
